### PR TITLE
Multiple SubFolders chmod fix using the "volume:" flag in the docker-compose.yml

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -103,10 +103,11 @@ function createUser() {
             if [ ! -d "$dirPath" ]; then
                 log "Creating directory: $dirPath"
                 mkdir -p $dirPath
-                chown -R $uid:users $dirPath
             else
                 log "Directory already exists: $dirPath"
             fi
+            log "Change the ownership of $dirPath for $uid:users"
+            chown -R $uid:users $dirPath
         done
     fi
 }


### PR DESCRIPTION
In my case I have multiple nested required sub folders using the "volumes:"

The user can read/write into SubFolder1/ and SubFolder1/NestedFolder1
The user can also read/write into SubFolder2/ and SubFolder2/NestedFolder2

Example:

```
sftp:
    image: atmoz/sftp
    ports:
      - "2222:22"
    volumes:

      - ./shared/sftp/SubFolder1/NestedFolder1:/home/myuser/SubFolder1/NestedFolder1
      - ./shared/sftp/SubFolder2/NestedFolder2:/home/myuser/SubFolder2/NestedFolder2

    command: myuser:mypass:1001:1002:SubFolder1,SubFolder2

```